### PR TITLE
Be more defensive against invalid responses

### DIFF
--- a/node_modules/wemonode/index.js
+++ b/node_modules/wemonode/index.js
@@ -306,12 +306,16 @@ function WemoNode() {
                 if (err) {
                     return;
                 }
-                var currentState = response.substr(response.indexOf('<BinaryState>'));
-                currentState = currentState.substr(13, 1);
 
-                if (singleObject.binarystate != currentState) {
-                    singleObject.binarystate = +currentState;
-                    this.emit("state_changed", singleObject);
+                var binaryStateIndex = response.indexOf('<BinaryState>');
+                if (binaryStateIndex !== -1) {
+                    var currentState = response.substr(binaryStateIndex);
+                    currentState = currentState.substr(13, 1);
+
+                    if (singleObject.binarystate != currentState) {
+                        singleObject.binarystate = +currentState;
+                        this.emit("state_changed", singleObject);
+                    }
                 }
             }.bind(this));
         }.bind(this));


### PR DESCRIPTION
I found that I was getting empty responses on occasion which would cause the binary state to flip when it hadn't actually. This just assures that the response is in the format expected.